### PR TITLE
Update SCFOps.td

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -1143,7 +1143,7 @@ def IndexSwitchOp : SCF_Op<"index_switch", [RecursiveMemoryEffects,
     Example:
 
     ```mlir
-    %0 = scf.index_switch %arg0 : index -> i32
+    %0 = scf.index_switch %arg0 -> i32
     case 2 {
       %1 = arith.constant 10 : i32
       scf.yield %1 : i32


### PR DESCRIPTION
Remove the extra ": index" in IndexSwitchOp description.

The current code example cannot be recognized by MLIR binary. It reports an error: "custom op 'scf.index_switch' expected 'default'".

According to the assemblyFormat listed below, there is no such a ": index" part after the argument. It can be confirmed in test files such as [this](https://github.com/llvm/llvm-project/blob/e468c60c96e1af1945179c2ca80b7a9dfcd38398/mlir/test/Dialect/SCF/ops.mlir#L417). The argument type doe not need to be specified since it must be index (as indicated by the operator name).

It is a tiny change, but essential in some sense. This description will be posted as the [documentation](https://mlir.llvm.org/docs/Dialects/SCFDialect/#scfindex_switch-scfindexswitchop) of MLIR. I followed this example but received an error. After struggling for a while, I finally found the problem. Hope this change may help others like me!